### PR TITLE
Updates for 2026.6.1 and updated actions

### DIFF
--- a/.github/workflows/docker-build-automatically.yml
+++ b/.github/workflows/docker-build-automatically.yml
@@ -1,7 +1,7 @@
 name: Build and Push Docker Image automatically
 on:
   schedule:
-    - cron: '42 */6 * * *'
+    - cron: '42 * * * *'
   workflow_dispatch:
     inputs:
       force_build:

--- a/.github/workflows/docker-build-automatically.yml
+++ b/.github/workflows/docker-build-automatically.yml
@@ -23,11 +23,12 @@ jobs:
     steps:
       - name: Get Latest Release
         id: latest_release
-        uses: pozetroninc/github-action-get-latest-release@master
+        uses: rez0n/actions-github-release@main
         with:
-          owner: 'paviro'
-          repo: 'KoShelf'
-          excludes: ''
+          token: ${{ secrets.GH_TOKEN }}
+          repository: "paviro/KoShelf"
+          type: "latest"
+      
                                                                                                                                                                      
       - name: Display Latest Release  
         run: |

--- a/.github/workflows/docker-build-automatically.yml
+++ b/.github/workflows/docker-build-automatically.yml
@@ -58,16 +58,16 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -75,7 +75,7 @@ jobs:
           
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: |
@@ -92,7 +92,7 @@ jobs:
             type=sha,prefix=sha-
             
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -76,11 +76,14 @@ This setup allows for seamless syncing of your reading data between devices whil
 |KOSHELF_MIN_PAGES_PER_DAY: 3|--min-pages-per-day|Minimum pages read per book per day to be counted in statistics|
 |KOSHELF_MIN_TIME_PER_DAY: "10m"|--min-time-per-day|Minimum reading time per book per day to be counted in statistics (e.g., "15m", "1h") <br> Note: If both KOSHELF_MIN_PAGES_PER_DAY and KOSHELF_MIN_TIME_PER_DAY are provided, a book's data for a day is counted if either condition is met for that book on that day. These filters apply per book per day, meaning each book must individually meet the threshold for each day to be included in statistics.|
 |KOSHELF_INCLUDE_ALL_STATS: True|--include-all-stats|By default, statistics are filtered to only include books present in your KOSHELF_BOOKS_PATH directory. This prevents deleted books or external files (like Wallabag articles) from skewing your recap and statistics. Use this flag to include statistics for all books in the database, regardless of whether they exist in your library.|
-|KOSHELF_IGNORE_STABLE_METADATA: "false"|--ignore-stable-page-metadata|Ignore KOReader stable page metadata for page totals and page-based stats scaling. By default, stable metadata is used when available.|
+|KOSHELF_IGNORE_STABLE_METADATA: "FALSE"|--ignore-stable-page-metadata|Ignore KOReader stable page metadata for page totals and page-based stats scaling. By default, stable metadata is used when available.|
 |KOSHELF_LANGUAGE: "de_DE"|--language|Language for UI translations. Use full locale code (e.g., en_US, de_DE, pt_BR) for correct date formatting. Default: en_US|
 |KOSHELF_ENABLE_AUTH: TRUE|--enable-auth|start server with auth enabled (on first run, KoShelf generates a password and prints it once) for details see https://github.com/paviro/KoShelf/blob/main/docs/authentication.md|
-|KOSHELF_ENABLE_WRITEBACK: TRUE|--enable-writeback|writeback enabled (edit annotations and metadata from the UI) for this to work the folder KOSHELF_LIBRARY_PATH (or if used KOSHELF_DOCSETTINGS_PATH or KOSHELF_HASHDOCSETTINGS_PATH) or with the booksneeds to be writable for user with id 1000
-|KOSHELF_TRUSTED_PROXIES: True|--trusted-proxies|Comma-separated or repeated trusted reverse proxy IP/CIDR entries for forwarded client IP/proto resolution|
+|KOSHELF_ENABLE_WRITEBACK: TRUE|--enable-writeback|writeback enabled (edit annotations and metadata from the UI) for this to work the folder 
+|KOSHELF_TRUSTED_PROXIES: TRUE|--trusted-proxies|Comma-separated or repeated trusted reverse proxy IP/CIDR entries for forwarded client IP/proto resolution|
+|KOSHELF_ENABLE_WRITEBACK: FALSE|--kobo-db|Path to Kobo's KoboReader.sqlite database. Used to discover matched extensionless kepub files and parse them as EPUBs. Requires --library-path.|
+
+KOSHELF_LIBRARY_PATH (or if used KOSHELF_DOCSETTINGS_PATH or KOSHELF_HASHDOCSETTINGS_PATH)  needs to be writable for user with id 1000
 
 
 for detailed information regarding the cli flags please look at the [Koshelf](https://github.com/paviro/KoShelf) repository too.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,5 +89,13 @@ if [ -n "$KOSHELF_TRUSTED_PROXIES" ]; then
     ARGS="$ARGS --trusted-proxies $KOSHELF_TRUSTED_PROXIES"
 fi
 
+if [ -n "$KOSHELF_ENABLE_WRITEBACK" ]; then
+    ARGS="$ARGS --enable-writeback $KOSHELF_ENABLE_WRITEBACK"
+fi
+
+if [ -n "$KOSHELF_KOBO_DB" ]; then
+    ARGS="$ARGS --kobo-db $KOSHELF_KOBO_DB"
+fi
+
 echo "Starting KoShelf with: koshelf serve $ARGS $@"
 eval exec koshelf serve $ARGS "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,8 +89,8 @@ if [ -n "$KOSHELF_TRUSTED_PROXIES" ]; then
     ARGS="$ARGS --trusted-proxies $KOSHELF_TRUSTED_PROXIES"
 fi
 
-if [ -n "$KOSHELF_ENABLE_WRITEBACK" ]; then
-    ARGS="$ARGS --enable-writeback $KOSHELF_ENABLE_WRITEBACK"
+if [ "KOSHELF_ENABLE_WRITEBACK" = "true" ]; then
+    ARGS="$ARGS -enable-writeback"
 fi
 
 if [ -n "$KOSHELF_KOBO_DB" ]; then


### PR DESCRIPTION
Updated the README.md and entrypoint.sh to 2026.6.1

In addition updated the actions to no longer use node20 as github deprecated that